### PR TITLE
docs: add all remaining built-in module pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -64,6 +64,12 @@ export default defineConfig({
 					items: [
 						{ slug: 'built-in-modules/auth' },
 						{ slug: 'built-in-modules/rbac' },
+						{ slug: 'built-in-modules/tenant' },
+						{ slug: 'built-in-modules/billing' },
+						{ slug: 'built-in-modules/notification' },
+						{ slug: 'built-in-modules/apikey' },
+						{ slug: 'built-in-modules/webhook' },
+						{ slug: 'built-in-modules/audit' },
 					],
 				},
 				{ label: 'CLI Reference', slug: 'cli-reference' },

--- a/src/components/landing/ModuleShowcase.astro
+++ b/src/components/landing/ModuleShowcase.astro
@@ -35,6 +35,96 @@
           <li>CLI: devify rbac:assign-role</li>
         </ul>
       </div>
+      <div class="module-card reveal">
+        <div class="module-header">
+          <span class="module-name">tenant</span>
+          <span class="module-badge core">CORE</span>
+        </div>
+        <ul>
+          <li>Multi-tenant workspace isolation</li>
+          <li>Member management with roles</li>
+          <li>Email invites with token acceptance</li>
+          <li>Header / subdomain / path resolution</li>
+          <li>Auto-create personal tenant on signup</li>
+          <li>ResolveTenant / RequireTenant middleware</li>
+          <li>Events: TenantCreated, MemberAdded</li>
+        </ul>
+      </div>
+      <div class="module-card reveal">
+        <div class="module-header">
+          <span class="module-name">billing</span>
+          <span class="module-badge core">CORE</span>
+        </div>
+        <ul>
+          <li>Plan &amp; subscription management</li>
+          <li>Stripe, Paddle, PayPal + noop gateways</li>
+          <li>Usage metering &amp; limit enforcement</li>
+          <li>Payment methods &amp; invoices</li>
+          <li>Inbound payment webhooks</li>
+          <li>Auto-seed plans, auto-provision subs</li>
+          <li>CLI: devify billing:set-plan</li>
+        </ul>
+      </div>
+      <div class="module-card reveal">
+        <div class="module-header">
+          <span class="module-name">notification</span>
+          <span class="module-badge core">CORE</span>
+        </div>
+        <ul>
+          <li>In-app notification bell</li>
+          <li>Unread count, mark read, mark all</li>
+          <li>User preferences &amp; muted types</li>
+          <li>Optional email delivery</li>
+          <li>Event-driven: invites, billing alerts</li>
+          <li>Configurable per-user limit</li>
+          <li>Auto-cleanup scheduled task</li>
+        </ul>
+      </div>
+      <div class="module-card reveal">
+        <div class="module-header">
+          <span class="module-name">apikey</span>
+          <span class="module-badge core">CORE</span>
+        </div>
+        <ul>
+          <li>Programmatic API access via keys</li>
+          <li>dvfy_ prefix, SHA-256 hashed storage</li>
+          <li>Global auth middleware (falls through)</li>
+          <li>Optional tenant scope &amp; permissions</li>
+          <li>Works alongside session/JWT auth</li>
+          <li>last_used_at tracking</li>
+          <li>Events: KeyCreated, KeyRevoked</li>
+        </ul>
+      </div>
+      <div class="module-card reveal">
+        <div class="module-header">
+          <span class="module-name">webhook</span>
+          <span class="module-badge core">CORE</span>
+        </div>
+        <ul>
+          <li>Outgoing webhooks per tenant</li>
+          <li>HMAC-SHA256 payload signing</li>
+          <li>Delivery tracking &amp; retry logs</li>
+          <li>Exponential backoff (5 retries)</li>
+          <li>Subscribes to all platform events</li>
+          <li>Test delivery endpoint</li>
+          <li>Auto-cleanup of old deliveries</li>
+        </ul>
+      </div>
+      <div class="module-card reveal">
+        <div class="module-header">
+          <span class="module-name">audit</span>
+          <span class="module-badge core">CORE</span>
+        </div>
+        <ul>
+          <li>Immutable append-only audit trail</li>
+          <li>Auto-logs all platform events</li>
+          <li>IP address &amp; User-Agent capture</li>
+          <li>Query by tenant, actor, action, date</li>
+          <li>Tenant-scoped &amp; system-wide views</li>
+          <li>Configurable retention policy</li>
+          <li>LogFromContext for easy logging</li>
+        </ul>
+      </div>
       <div class="module-card custom reveal">
         <div class="module-header">
           <span class="module-name">your-module</span>

--- a/src/content/docs/built-in-modules/apikey.mdx
+++ b/src/content/docs/built-in-modules/apikey.mdx
@@ -1,0 +1,89 @@
+---
+title: API Key Module
+description: Built-in API key module — programmatic API access via long-lived keys as an alternative to session/JWT authentication.
+---
+
+The API key module provides programmatic API access via long-lived keys. It serves as an alternative to session or JWT authentication, ideal for CI/CD pipelines, scripts, and third-party integrations. Keys are SHA-256 hashed at rest and the plaintext is shown only once on creation.
+
+## Features
+
+- Programmatic API access via API keys
+- Alternative to session/JWT authentication
+- Key format: `dvfy_` prefix + 32 hex chars
+- SHA-256 hashed storage (plaintext shown once on creation)
+- Prefix-based lookup for fast validation
+- Optional tenant scope
+- Optional permission scopes
+- Optional expiry
+- Configurable max keys per user
+- `last_used_at` tracking
+
+## Configuration
+
+```toml
+[modules.apikey]
+max_keys_per_user = 10
+default_expiry = ""
+key_prefix = "dvfy_"
+```
+
+## Dependencies
+
+```go
+func (m *Module) Dependencies() []string {
+    return []string{"auth"}
+}
+```
+
+The API key module uses `auth.UserService` to resolve the user associated with a validated key.
+
+## HTTP Routes
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| POST | `/api-keys` | Create key (returns plaintext once) | RequireAuth |
+| GET | `/api-keys` | List user's keys | RequireAuth |
+| GET | `/api-keys/{id}` | Get key details (no plaintext) | RequireAuth |
+| DELETE | `/api-keys/{id}` | Revoke key | RequireAuth |
+
+## APIKeyService Interface
+
+Exported as `apikey.service`:
+
+```go
+type APIKeyService interface {
+    Create(ctx context.Context, userID uuid.UUID, tenantID *uuid.UUID, name string, scopes []string, expiresAt *time.Time) (key string, apiKey *APIKey, err error)
+    List(ctx context.Context, userID uuid.UUID) ([]APIKey, error)
+    GetByID(ctx context.Context, id, userID uuid.UUID) (*APIKey, error)
+    Revoke(ctx context.Context, id, userID uuid.UUID) error
+    Validate(ctx context.Context, rawKey string) (*APIKey, error)
+    TouchLastUsed(ctx context.Context, id uuid.UUID) error
+}
+```
+
+## Events
+
+| Event Name | Payload | When |
+|-----------|---------|------|
+| `apikey.created` | `*APIKey` | After a new key is created |
+| `apikey.revoked` | `*APIKey` | After a key is revoked |
+
+## Middleware
+
+- **AuthenticateAPIKey** — global middleware (via `HasMiddleware`). Checks the `Authorization: Bearer dvfy_xxx` header. If the prefix matches, validates the key and injects the user ID and optional tenant ID into the request context using the same context keys as the auth module. If no `dvfy_` prefix is found, the middleware falls through to session/JWT authentication. Works alongside session/JWT auth seamlessly.
+
+```go
+apikeymw.AuthenticateAPIKey(apiKeyService)
+```
+
+## Scheduled Tasks
+
+| Task | Schedule | Description |
+|------|----------|-------------|
+| `apikey.cleanup` | Daily | Deletes keys that expired more than 30 days ago |
+
+## Database Tables
+
+| Table | Schema |
+|-------|--------|
+| `apikey.keys` | id, user_id, tenant_id, name, prefix, key_hash, scopes (TEXT[]), expires_at, last_used_at, revoked_at, created_at |

--- a/src/content/docs/built-in-modules/audit.mdx
+++ b/src/content/docs/built-in-modules/audit.mdx
@@ -1,0 +1,99 @@
+---
+title: Audit Module
+description: Built-in audit trail — immutable append-only logging of who did what, when, for compliance and security.
+---
+
+The audit module provides an immutable, append-only audit trail for compliance and security logging. It automatically captures events from all other modules via the EventBus and enriches entries with request metadata (IP address, user agent) through its global middleware.
+
+## Features
+
+- Immutable append-only audit trail
+- "Who did what, when" — compliance and security logging
+- Automatic event-driven logging from all other modules
+- `CaptureRequestInfo` middleware for IP and User-Agent tracking
+- `LogFromContext` extracts actor, tenant, IP, and user-agent from context
+- Query with filters: tenant, actor, action, resource, date range
+- Pagination support
+- Configurable retention with scheduled cleanup
+- Tenant-scoped and system-wide query endpoints
+
+## Configuration
+
+```toml
+[modules.audit]
+retention_days = 365
+enabled = true
+```
+
+## Dependencies
+
+```go
+func (m *Module) Dependencies() []string {
+    return []string{"auth", "rbac", "tenant"}
+}
+```
+
+The audit module uses `auth.UserService` for actor resolution, the RBAC module for admin role checks on the system-wide endpoint, and the tenant module for tenant-scoped isolation.
+
+## HTTP Routes
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| GET | `/tenants/{id}/audit` | Query tenant audit log | RequireTenant |
+| GET | `/audit` | Query system audit log | RequireRole("admin") |
+
+### Query Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `action` | string | Filter by action name |
+| `resource_type` | string | Filter by resource type |
+| `resource_id` | string | Filter by resource ID |
+| `actor_id` | UUID | Filter by actor user ID |
+| `from` | RFC 3339 | Start of date range |
+| `to` | RFC 3339 | End of date range |
+| `limit` | int | Max entries to return |
+| `offset` | int | Pagination offset |
+
+## AuditService Interface
+
+Exported as `audit.service`:
+
+```go
+type AuditService interface {
+    Log(ctx context.Context, entry *Entry) error
+    LogFromContext(ctx context.Context, action, resourceType, resourceID string, metadata map[string]any) error
+    Query(ctx context.Context, filter *QueryFilter) ([]Entry, int, error)
+}
+```
+
+## Event Subscriptions
+
+The audit module subscribes to events from all other modules and automatically logs them:
+
+| Source Module | Events |
+|--------------|--------|
+| auth | `auth.user_registered`, `auth.user_logged_in`, `auth.user_logged_out`, `auth.password_reset` |
+| tenant | `tenant.created`, `tenant.deleted`, `tenant.member_added`, `tenant.member_removed`, `tenant.invite_created`, `tenant.invite_accepted` |
+| billing | `billing.subscription_created`, `billing.plan_changed`, `billing.subscription_canceled`, `billing.payment_succeeded`, `billing.payment_failed`, `billing.limit_reached` |
+| apikey | `apikey.created`, `apikey.revoked` |
+
+## Middleware
+
+- **CaptureRequestInfo** — global middleware (via `HasMiddleware`). Extracts the client IP address (from `X-Forwarded-For`, `X-Real-IP`, or `RemoteAddr`) and `User-Agent` header into the request context. The `LogFromContext` method reads these values automatically when creating audit entries.
+
+```go
+auditmw.CaptureRequestInfo()
+```
+
+## Scheduled Tasks
+
+| Task | Schedule | Description |
+|------|----------|-------------|
+| `audit.cleanup` | Daily | Deletes entries older than `retention_days` |
+
+## Database Tables
+
+| Table | Schema |
+|-------|--------|
+| `audit.entries` | id, tenant_id, actor_id, action, resource_type, resource_id, metadata (JSONB), ip_address, user_agent, created_at |

--- a/src/content/docs/built-in-modules/billing.mdx
+++ b/src/content/docs/built-in-modules/billing.mdx
@@ -1,0 +1,134 @@
+---
+title: Billing Module
+description: Built-in billing module — plans, subscriptions, payment gateways, invoices, and usage metering.
+---
+
+The billing module manages plans, subscriptions, payment processing, and usage-based metering. It abstracts payment gateways behind a common interface and supports Stripe, Paddle, PayPal, and a noop gateway for development. It depends on the [auth module](/built-in-modules/auth/) and [tenant module](/built-in-modules/tenant/).
+
+## Features
+
+- Plan management with feature limits (JSONB)
+- Subscription lifecycle (subscribe, upgrade, downgrade, cancel)
+- Payment gateway abstraction (Stripe, Paddle, PayPal, noop)
+- Paddle acts as Merchant of Record for EU VAT
+- Gateway customer mapping
+- Payment method management (setup intents, list, default, detach)
+- Invoice tracking
+- Usage-based metering and limit enforcement
+- Inbound payment provider webhooks
+- Auto-seed default plans on first boot (free, pro, enterprise)
+- Auto-provision free subscription on tenant creation
+
+## Configuration
+
+```toml
+[modules.billing]
+gateway = "noop"
+default_plan = "free"
+trial_days = 0
+auto_seed_plans = true
+currency = "usd"
+```
+
+## Dependencies
+
+```go
+func (m *Module) Dependencies() []string {
+    return []string{"auth", "tenant"}
+}
+```
+
+The billing module uses `tenant.TenantService` to associate subscriptions with tenants and listens to tenant lifecycle events.
+
+## HTTP Routes
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| GET | `/plans` | List active plans | Public |
+| POST | `/plans` | Create plan | RequireRole("admin") |
+| PATCH | `/plans/{id}` | Update plan | RequireRole("admin") |
+| GET | `/tenants/{id}/subscription` | Get subscription | RequireTenant |
+| POST | `/tenants/{id}/subscription` | Subscribe to plan | RequireTenantRole(owner, admin) |
+| PATCH | `/tenants/{id}/subscription` | Change plan | RequireTenantRole(owner, admin) |
+| DELETE | `/tenants/{id}/subscription` | Cancel subscription | RequireTenantRole(owner) |
+| POST | `/tenants/{id}/payment-methods/setup` | Create setup intent | RequireTenantRole(owner, admin) |
+| GET | `/tenants/{id}/payment-methods` | List payment methods | RequireTenantRole(owner, admin) |
+| PATCH | `/tenants/{id}/payment-methods/{pmid}/default` | Set default | RequireTenantRole(owner, admin) |
+| DELETE | `/tenants/{id}/payment-methods/{pmid}` | Detach method | RequireTenantRole(owner, admin) |
+| GET | `/tenants/{id}/invoices` | List invoices | RequireTenant |
+| GET | `/tenants/{id}/usage` | Get usage metrics | RequireTenant |
+| POST | `/billing/webhooks/{gateway}` | Inbound gateway webhooks | Signature verified |
+
+## BillingService Interface
+
+Exported for other modules via DI as `billing.service`:
+
+```go
+type BillingService interface {
+    CreatePlan(ctx context.Context, name, displayName string, priceCents int, currency string, features map[string]any, gatewayPriceID string) (*Plan, error)
+    GetPlan(ctx context.Context, id uuid.UUID) (*Plan, error)
+    GetPlanByName(ctx context.Context, name string) (*Plan, error)
+    ListPlans(ctx context.Context) ([]Plan, error)
+    UpdatePlan(ctx context.Context, id uuid.UUID, displayName string, priceCents int, features map[string]any) (*Plan, error)
+    GetOrCreateCustomer(ctx context.Context, tenantID uuid.UUID) (*Customer, error)
+    CreateSetupIntent(ctx context.Context, tenantID uuid.UUID) (string, error)
+    ListPaymentMethods(ctx context.Context, tenantID uuid.UUID) ([]PaymentMethodInfo, error)
+    SetDefaultPaymentMethod(ctx context.Context, tenantID uuid.UUID, paymentMethodID string) error
+    DetachPaymentMethod(ctx context.Context, tenantID uuid.UUID, paymentMethodID string) error
+    Subscribe(ctx context.Context, tenantID, planID uuid.UUID) (*Subscription, error)
+    GetSubscription(ctx context.Context, tenantID uuid.UUID) (*Subscription, error)
+    ChangePlan(ctx context.Context, tenantID, newPlanID uuid.UUID) (*Subscription, error)
+    CancelSubscription(ctx context.Context, tenantID uuid.UUID, atPeriodEnd bool) error
+    ListInvoices(ctx context.Context, tenantID uuid.UUID, limit int) ([]Invoice, error)
+    GetUsage(ctx context.Context, tenantID uuid.UUID, featureKey string) (int64, error)
+    IncrementUsage(ctx context.Context, tenantID uuid.UUID, featureKey string, delta int64) error
+    CheckLimit(ctx context.Context, tenantID uuid.UUID, featureKey string) (allowed bool, current, limit int64, err error)
+    HandleGatewayWebhook(ctx context.Context, payload []byte, signature string) error
+    CreateDefaultSubscription(ctx context.Context, tenantID uuid.UUID) (*Subscription, error)
+}
+```
+
+## Events
+
+| Event Name | Payload | When |
+|-----------|---------|------|
+| `billing.subscription_created` | `*Subscription` | After a new subscription is created |
+| `billing.plan_changed` | `*Subscription` | After a subscription plan is changed |
+| `billing.subscription_canceled` | `*Subscription` | After a subscription is canceled |
+| `billing.payment_succeeded` | `*Invoice` | After a payment succeeds |
+| `billing.payment_failed` | `*Invoice` | After a payment fails |
+| `billing.limit_reached` | `*UsageAlert` | When a usage limit is reached |
+
+## Event Subscriptions
+
+The billing module subscribes to `tenant.created` and automatically provisions a free subscription and gateway customer for new tenants:
+
+```go
+func (m *Module) RegisterEvents(bus kernel.EventBus) {
+    bus.Subscribe("tenant.created", func(e kernel.Event) error {
+        tenant := e.Payload.(*tenantpkg.Tenant)
+        _, _ = m.billingService.GetOrCreateCustomer(context.Background(), tenant.ID)
+        _, err := m.billingService.CreateDefaultSubscription(context.Background(), tenant.ID)
+        return err
+    })
+}
+```
+
+## CLI Commands
+
+```bash
+devify billing:list-plans
+devify billing:create-plan
+devify billing:set-plan
+devify billing:sync-plans
+```
+
+## Database Tables
+
+| Table | Schema |
+|-------|--------|
+| `billing.plans` | id, name, display_name, price_cents, currency, features (JSONB), gateway_price_id, is_active, sort_order, created_at, updated_at |
+| `billing.customers` | id, tenant_id, gateway, external_id, created_at |
+| `billing.subscriptions` | id, tenant_id, plan_id, gateway_subscription_id, status, current_period_start, current_period_end, cancel_at_period_end, canceled_at, created_at, updated_at |
+| `billing.invoices` | id, tenant_id, gateway_invoice_id, amount_cents, currency, status, period_start, period_end, paid_at, hosted_url, created_at |
+| `billing.usage` | id, tenant_id, feature_key, current_value, updated_at |

--- a/src/content/docs/built-in-modules/notification.mdx
+++ b/src/content/docs/built-in-modules/notification.mdx
@@ -1,0 +1,135 @@
+---
+title: Notification Module
+description: Built-in notification module — in-app notifications, unread tracking, preferences, and optional email delivery.
+---
+
+The notification module provides an in-app notification system. It handles user-scoped notifications, unread count tracking, per-user preferences, and optional email delivery. It reacts to events from other modules to automatically notify users. It depends on the [auth module](/built-in-modules/auth/) for user identity. Tenant integration is optional.
+
+## Features
+
+- In-app notification system (notification bell)
+- User-scoped notifications
+- Unread count tracking
+- Mark read / mark all read
+- Notification preferences (channels, muted types)
+- Optional email delivery
+- Event-driven — auto-notifies on tenant invites, billing events
+- Configurable per-user limit and cleanup
+
+## Configuration
+
+```toml
+[modules.notification]
+email_enabled = true
+max_per_user = 500
+cleanup_after_days = 90
+```
+
+## Dependencies
+
+```go
+func (m *Module) Dependencies() []string {
+    return []string{"auth"}
+}
+```
+
+The notification module uses `auth.UserService` to resolve users. Tenant integration is optional — when the [tenant module](/built-in-modules/tenant/) is present, the notification module subscribes to tenant events.
+
+## HTTP Routes
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| GET | `/notifications` | List notifications (?unread=true&limit=20&offset=0) | RequireAuth |
+| GET | `/notifications/unread-count` | Get unread count | RequireAuth |
+| PATCH | `/notifications/{id}/read` | Mark as read | RequireAuth |
+| POST | `/notifications/read-all` | Mark all as read | RequireAuth |
+| DELETE | `/notifications/{id}` | Delete notification | RequireAuth |
+| GET | `/notifications/preferences` | Get preferences | RequireAuth |
+| PATCH | `/notifications/preferences` | Update preferences | RequireAuth |
+
+## NotificationService Interface
+
+Exported for other modules via DI as `notification.service`:
+
+```go
+type NotificationService interface {
+    Send(ctx context.Context, userID uuid.UUID, typ, title, body string, metadata map[string]any) (*Notification, error)
+    List(ctx context.Context, userID uuid.UUID, unreadOnly bool, limit, offset int) ([]Notification, int, error)
+    MarkRead(ctx context.Context, id, userID uuid.UUID) error
+    MarkAllRead(ctx context.Context, userID uuid.UUID) error
+    UnreadCount(ctx context.Context, userID uuid.UUID) (int, error)
+    Delete(ctx context.Context, id, userID uuid.UUID) error
+    GetPreferences(ctx context.Context, userID uuid.UUID) (*Preferences, error)
+    UpdatePreferences(ctx context.Context, userID uuid.UUID, channels map[string]bool, mutedTypes []string) error
+}
+```
+
+## Events
+
+| Event Name | Payload | When |
+|-----------|---------|------|
+| `notification.sent` | `*Notification` | After a notification is sent to a user |
+
+## Event Subscriptions
+
+The notification module subscribes to events from the tenant and billing modules to automatically notify users:
+
+```go
+func (m *Module) RegisterEvents(bus kernel.EventBus) {
+    bus.Subscribe("tenant.invite_created", func(e kernel.Event) error {
+        invite := e.Payload.(*tenantpkg.Invite)
+        _, err := m.notificationService.Send(context.Background(), invite.UserID,
+            "tenant.invite", "You've been invited", "You were invited to join a workspace.",
+            map[string]any{"tenant_id": invite.TenantID, "token": invite.Token})
+        return err
+    })
+
+    bus.Subscribe("tenant.member_added", func(e kernel.Event) error {
+        member := e.Payload.(*tenantpkg.Member)
+        _, err := m.notificationService.Send(context.Background(), member.UserID,
+            "tenant.member_added", "Welcome", "You were added to a workspace.",
+            map[string]any{"tenant_id": member.TenantID})
+        return err
+    })
+
+    bus.Subscribe("billing.limit_reached", func(e kernel.Event) error {
+        alert := e.Payload.(*billingpkg.UsageAlert)
+        _, err := m.notificationService.Send(context.Background(), alert.OwnerID,
+            "billing.limit_reached", "Usage limit reached",
+            "You have reached the limit for "+alert.FeatureKey+".",
+            map[string]any{"feature_key": alert.FeatureKey})
+        return err
+    })
+
+    bus.Subscribe("billing.plan_changed", func(e kernel.Event) error {
+        sub := e.Payload.(*billingpkg.Subscription)
+        _, err := m.notificationService.Send(context.Background(), sub.OwnerID,
+            "billing.plan_changed", "Plan updated", "Your subscription plan has been changed.",
+            map[string]any{"plan_id": sub.PlanID})
+        return err
+    })
+}
+```
+
+## Scheduled Tasks
+
+```go
+func (m *Module) ScheduledTasks() []kernel.ScheduledTask {
+    return []kernel.ScheduledTask{
+        {
+            Name:     "notification.cleanup",
+            Schedule: "@daily",
+            Handler:  m.cleanupOldNotifications,
+        },
+    }
+}
+```
+
+Deletes notifications older than `cleanup_after_days` (default: 90 days).
+
+## Database Tables
+
+| Table | Schema |
+|-------|--------|
+| `notification.notifications` | id, user_id, type, title, body, metadata (JSONB), read_at, created_at |
+| `notification.preferences` | id, user_id, channels (JSONB), muted_types (TEXT[]), updated_at |

--- a/src/content/docs/built-in-modules/tenant.mdx
+++ b/src/content/docs/built-in-modules/tenant.mdx
@@ -1,0 +1,122 @@
+---
+title: Tenant Module
+description: Built-in multi-tenant module — workspace isolation, member management, and invite system.
+---
+
+The tenant module provides multi-tenant workspace isolation. It handles tenant creation, slug-based identification, member management with roles, and email-based invitations. It depends on the [auth module](/built-in-modules/auth/) for user identity.
+
+## Features
+
+- Multi-tenant workspace isolation
+- Create, update, and delete tenants
+- Slug-based tenant identification
+- Member management with roles (owner, admin, member)
+- Email invites with token-based acceptance
+- Tenant resolution: header, subdomain, or path (configurable)
+- Auto-create personal tenant on user registration
+- Configurable max tenants per user
+
+## Configuration
+
+```toml
+[modules.tenant]
+resolution = "header"
+header_name = "X-Tenant-ID"
+auto_create_personal = true
+max_tenants_per_user = 10
+invite_expiry = "72h"
+```
+
+## Dependencies
+
+```go
+func (m *Module) Dependencies() []string {
+    return []string{"auth"}
+}
+```
+
+The tenant module uses `auth.UserService` to look up users when managing members and processing invitations.
+
+## HTTP Routes
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| POST | `/tenants` | Create tenant | RequireAuth |
+| GET | `/tenants` | List user's tenants | RequireAuth |
+| GET | `/tenants/{id}` | Get tenant | RequireTenant |
+| PATCH | `/tenants/{id}` | Update tenant | RequireTenantRole(owner) |
+| DELETE | `/tenants/{id}` | Delete tenant | RequireTenantRole(owner) |
+| GET | `/tenants/{id}/members` | List members | RequireTenant |
+| POST | `/tenants/{id}/members/invite` | Invite member | RequireTenantRole(owner, admin) |
+| POST | `/tenants/{id}/members/accept` | Accept invite | RequireAuth |
+| DELETE | `/tenants/{id}/members/{uid}` | Remove member | RequireTenantRole(owner, admin) |
+| PATCH | `/tenants/{id}/members/{uid}` | Update member role | RequireTenantRole(owner) |
+
+## TenantService Interface
+
+Exported for other modules via DI as `tenant.service`:
+
+```go
+type TenantService interface {
+    Create(ctx context.Context, name, slug string, ownerID uuid.UUID) (*Tenant, error)
+    GetByID(ctx context.Context, id uuid.UUID) (*Tenant, error)
+    GetBySlug(ctx context.Context, slug string) (*Tenant, error)
+    Update(ctx context.Context, id uuid.UUID, name string, settings map[string]any) (*Tenant, error)
+    Delete(ctx context.Context, id uuid.UUID) error
+    ListByUser(ctx context.Context, userID uuid.UUID) ([]TenantWithRole, error)
+    AddMember(ctx context.Context, tenantID, userID uuid.UUID, role string) error
+    RemoveMember(ctx context.Context, tenantID, userID uuid.UUID) error
+    UpdateMemberRole(ctx context.Context, tenantID, userID uuid.UUID, role string) error
+    GetMembers(ctx context.Context, tenantID uuid.UUID) ([]Member, error)
+    IsMember(ctx context.Context, tenantID, userID uuid.UUID) (bool, error)
+    InviteMember(ctx context.Context, tenantID uuid.UUID, email, role string, invitedBy uuid.UUID) (*Invite, error)
+    AcceptInvite(ctx context.Context, token string, userID uuid.UUID) error
+    CreatePersonalTenant(ctx context.Context, userID uuid.UUID, email string) (*Tenant, error)
+}
+```
+
+## Events
+
+| Event Name | Payload | When |
+|-----------|---------|------|
+| `tenant.created` | `*Tenant` | After a new tenant is created |
+| `tenant.deleted` | `*Tenant` | After a tenant is deleted |
+| `tenant.member_added` | `*Member` | After a member is added to a tenant |
+| `tenant.member_removed` | `*Member` | After a member is removed from a tenant |
+| `tenant.invite_created` | `*Invite` | After a new invite is sent |
+| `tenant.invite_accepted` | `*Invite` | After an invite is accepted |
+
+## Event Subscriptions
+
+The tenant module subscribes to `auth.user_registered` and automatically creates a personal tenant for new users when `auto_create_personal` is enabled:
+
+```go
+func (m *Module) RegisterEvents(bus kernel.EventBus) {
+    bus.Subscribe("auth.user_registered", func(e kernel.Event) error {
+        user := e.Payload.(*auth.User)
+        _, err := m.tenantService.CreatePersonalTenant(context.Background(), user.ID, user.Email)
+        return err
+    })
+}
+```
+
+## Middleware
+
+```go
+// Resolve tenant from header, subdomain, or path
+tenantmw.ResolveTenant(tenantService, config)
+
+// Require the user to be a member of the resolved tenant
+tenantmw.RequireTenant(tenantService)
+
+// Require the user to have a specific role within the tenant
+tenantmw.RequireTenantRole(tenantService, "owner", "admin")
+```
+
+## Database Tables
+
+| Table | Schema |
+|-------|--------|
+| `tenant.tenants` | id, name, slug, owner_id, settings, created_at, updated_at |
+| `tenant.members` | id, tenant_id, user_id, role, joined_at |
+| `tenant.invites` | id, tenant_id, email, role, token, invited_by, expires_at, accepted_at, created_at |

--- a/src/content/docs/built-in-modules/webhook.mdx
+++ b/src/content/docs/built-in-modules/webhook.mdx
@@ -1,0 +1,102 @@
+---
+title: Webhook Module
+description: Built-in outgoing webhook system — tenant-scoped event delivery with HMAC signing, retries, and delivery tracking.
+---
+
+The webhook module provides an outgoing webhook system for tenant-scoped event delivery. Tenants register endpoint URLs to receive event notifications, with HMAC-SHA256 payload signing, automatic retries with exponential backoff, and full delivery tracking.
+
+## Features
+
+- Outgoing webhook system for tenant-scoped event delivery
+- Tenants register URLs to receive event notifications
+- HMAC-SHA256 payload signing (`X-Devify-Signature` header)
+- Delivery tracking with full request/response logging
+- Exponential backoff retries: 1m, 5m, 30m, 2h, 24h (max 5 attempts)
+- Configurable max endpoints per tenant (default 20)
+- Event fan-out via EventBus subscribers
+- Test delivery endpoint for debugging
+- Cross-tenant isolation enforced at service layer
+
+## Configuration
+
+```toml
+[modules.webhook]
+max_endpoints_per_tenant = 20
+delivery_timeout = "10s"
+max_retries = 5
+cleanup_after_days = 30
+```
+
+## Dependencies
+
+```go
+func (m *Module) Dependencies() []string {
+    return []string{"auth", "tenant"}
+}
+```
+
+The webhook module uses `auth.UserService` for actor resolution and depends on the tenant module for tenant-scoped isolation.
+
+## HTTP Routes
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| POST | `/tenants/{id}/webhooks` | Create endpoint | RequireTenant |
+| GET | `/tenants/{id}/webhooks` | List endpoints | RequireTenant |
+| GET | `/tenants/{id}/webhooks/{wid}` | Get endpoint | RequireTenant |
+| PATCH | `/tenants/{id}/webhooks/{wid}` | Update endpoint | RequireTenant |
+| DELETE | `/tenants/{id}/webhooks/{wid}` | Delete endpoint | RequireTenant |
+| GET | `/tenants/{id}/webhooks/{wid}/deliveries` | List deliveries | RequireTenant |
+| POST | `/tenants/{id}/webhooks/{wid}/test` | Send test delivery | RequireTenant |
+
+## WebhookService Interface
+
+Exported as `webhook.service`:
+
+```go
+type WebhookService interface {
+    CreateEndpoint(ctx context.Context, tenantID uuid.UUID, url, secret string, events []string) (*Endpoint, error)
+    ListEndpoints(ctx context.Context, tenantID uuid.UUID) ([]Endpoint, error)
+    GetEndpoint(ctx context.Context, id, tenantID uuid.UUID) (*Endpoint, error)
+    UpdateEndpoint(ctx context.Context, id, tenantID uuid.UUID, url string, events []string, isActive bool) (*Endpoint, error)
+    DeleteEndpoint(ctx context.Context, id, tenantID uuid.UUID) error
+    Dispatch(ctx context.Context, tenantID uuid.UUID, eventName string, payload any) error
+    ListDeliveries(ctx context.Context, endpointID uuid.UUID, limit, offset int) ([]Delivery, error)
+    RetryDelivery(ctx context.Context, deliveryID uuid.UUID) error
+    ProcessRetries(ctx context.Context) error
+}
+```
+
+## Event Subscriptions
+
+The webhook module subscribes to events from other modules and dispatches them to matching tenant endpoints:
+
+| Source Module | Events |
+|--------------|--------|
+| auth | `auth.user_registered` |
+| tenant | `tenant.created`, `tenant.deleted`, `tenant.member_added`, `tenant.member_removed`, `tenant.invite_created`, `tenant.invite_accepted` |
+| billing | `billing.subscription_created`, `billing.plan_changed`, `billing.subscription_canceled`, `billing.payment_succeeded`, `billing.payment_failed` |
+
+## Delivery Flow
+
+1. An event fires via the kernel EventBus
+2. The webhook module finds all active endpoints for the tenant subscribed to that event
+3. For each matching endpoint, a delivery record is created
+4. The payload is signed with HMAC-SHA256 using the endpoint's secret
+5. The module POSTs to the endpoint URL with the `X-Devify-Signature: sha256=<hmac>` header
+6. The response status code and body are recorded on the delivery
+7. On failure (non-2xx or timeout), the delivery is scheduled for retry with exponential backoff
+
+## Scheduled Tasks
+
+| Task | Schedule | Description |
+|------|----------|-------------|
+| `webhook.retry` | Every 1 minute | Processes pending delivery retries |
+| `webhook.cleanup` | Daily | Deletes deliveries older than `cleanup_after_days` |
+
+## Database Tables
+
+| Table | Schema |
+|-------|--------|
+| `webhook.endpoints` | id, tenant_id, url, secret, events (TEXT[]), is_active, created_at, updated_at |
+| `webhook.deliveries` | id, endpoint_id, event_name, payload (JSONB), status_code, response_body, duration_ms, attempt, next_retry_at, delivered_at, created_at |


### PR DESCRIPTION
## Summary

- Adds documentation pages for 6 built-in modules: tenant, billing, notification, apikey, webhook, audit
- Updates sidebar navigation in `astro.config.mjs` to include all 8 modules
- Expands the landing page ModuleShowcase from 2 to 8 core module cards + custom

Each doc page follows the existing auth/rbac format: features, configuration, dependencies, HTTP routes, service interface, events, middleware, scheduled tasks, and database tables.

## New pages
- `/built-in-modules/tenant/`
- `/built-in-modules/billing/`
- `/built-in-modules/notification/`
- `/built-in-modules/apikey/`
- `/built-in-modules/webhook/`
- `/built-in-modules/audit/`

## Test plan
- [x] `npm run build` succeeds (37 pages built)
- [ ] Visual review of new pages