### PR TITLE
Add local development docs and update compose workflow

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -33,6 +33,7 @@ export default defineConfig({
 						{ slug: 'getting-started/installation' },
 						{ slug: 'getting-started/quick-start' },
 						{ slug: 'getting-started/project-structure' },
+						{ slug: 'getting-started/local-development' },
 					],
 				},
 				{

--- a/src/content/docs/cli-reference/index.mdx
+++ b/src/content/docs/cli-reference/index.mdx
@@ -3,7 +3,7 @@ title: CLI Reference
 description: Complete reference for all Devify CLI commands.
 ---
 
-The Devify CLI provides 18 built-in commands organized into 6 categories, plus dynamic module commands.
+The Devify CLI provides 19 built-in commands organized into 6 categories, plus dynamic module commands.
 
 ## Project Lifecycle
 
@@ -36,6 +36,16 @@ devify dev
 ```
 
 Wraps Air for automatic rebuilding on file changes. Watches `.go`, `.templ`, and `.toml` files.
+
+### devify compose
+
+Generate `compose.yml` from `config/config.toml`.
+
+```bash
+devify compose
+```
+
+Reads the current configuration and generates a `compose.yml` with containers for the selected database engine, cache adapter (if Redis), and Mailpit (in development mode). Also includes any custom services declared via `[services.*]` config sections. Regenerate after changing adapters in config.
 
 ### devify run
 

--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -8,7 +8,7 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 ## Prerequisites
 
 - **Go 1.22+** — [Download Go](https://go.dev/dl/)
-- **A database engine** — PostgreSQL (recommended), MySQL, SQLite, or MongoDB
+- **Docker or Podman** — for running database and service containers (recommended)
 - **Git** — for version control
 
 ## Install the CLI
@@ -33,6 +33,10 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 </Steps>
 
 ## Database Setup
+
+Devify generates a `compose.yml` for your project that runs the database (and other services) in containers. If you have Docker or Podman installed, no manual database setup is needed — just run `make dev`.
+
+If you prefer to install databases natively:
 
 <Tabs>
   <TabItem label="PostgreSQL" icon="seti:db">

--- a/src/content/docs/getting-started/local-development.mdx
+++ b/src/content/docs/getting-started/local-development.mdx
@@ -1,0 +1,114 @@
+---
+title: Local Development
+description: Run databases and services locally with containers and Make.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+Devify generates a `compose.yml` and `Makefile` for every project, giving you a single-command development environment.
+
+## How It Works
+
+When you run `devify init`, the CLI generates a `compose.yml` based on your selected database engine. The included `Makefile` wraps container orchestration so you never need to run `docker compose` or `podman compose` directly.
+
+```
+config/config.toml  →  devify compose  →  compose.yml  →  make dev
+```
+
+The Makefile auto-detects whether you have Podman or Docker installed.
+
+## Make Targets
+
+| Command | Description |
+|---------|-------------|
+| `make dev` | Start containers + hot-reload dev server (Air) |
+| `make build` | Build app and CLI binaries to `./bin/` |
+| `make test` | Start containers + run integration tests |
+| `make test-unit` | Run unit tests (no containers needed) |
+| `make vet` | Run `go vet` on all packages |
+| `make services-up` | Start database, cache, and mail containers |
+| `make services-down` | Stop containers |
+| `make services-reset` | Destroy volumes and restart containers (fresh database) |
+
+## What Gets Containerized
+
+The `devify compose` command reads `config/config.toml` and generates containers for:
+
+- **Database** — PostgreSQL, MySQL/MariaDB, or MongoDB (SQLite needs no container)
+- **Cache** — Redis (if `cache.engine = "redis"`; BadgerDB and in-memory need no container)
+- **Mail** — Mailpit SMTP server + web UI (in development mode only)
+
+### Default Ports
+
+| Service | Port | Web UI |
+|---------|------|--------|
+| PostgreSQL | 5432 | — |
+| MySQL/MariaDB | 3306 | — |
+| MongoDB | 27017 | — |
+| Redis | 6379 | — |
+| Mailpit SMTP | 1025 | [localhost:8025](http://localhost:8025) |
+
+## Regenerating compose.yml
+
+After changing adapters in `config/config.toml` (e.g., switching from PostgreSQL to MySQL), regenerate the compose file:
+
+```bash
+devify compose
+```
+
+This reads the current config and produces a fresh `compose.yml` with the correct containers, ports, and volumes.
+
+## Custom Services
+
+Modules can declare their own container dependencies using `[services.*]` sections in `config/config.toml`. These are automatically included when you run `devify compose`.
+
+```toml title="config/config.toml"
+[services.minio]
+image = "quay.io/minio/minio:latest"
+ports = ["9000:9000", "9001:9001"]
+volume_name = "miniodata"
+volume_path = "/data"
+
+[services.elasticsearch]
+image = "docker.io/library/elasticsearch:8.12.0"
+ports = ["9200:9200"]
+
+[services.elasticsearch.environment]
+discovery.type = "single-node"
+xpack.security.enabled = "false"
+```
+
+Each custom service supports:
+
+| Field | Description |
+|-------|-------------|
+| `image` | Container image (required) |
+| `ports` | List of port mappings |
+| `environment` | Key-value environment variables |
+| `volume_name` | Named volume identifier |
+| `volume_path` | Mount path inside the container |
+
+## Podman vs Docker
+
+The Makefile prefers Podman when available, falling back to Docker:
+
+<Tabs>
+  <TabItem label="Podman">
+    ```bash
+    # Podman is auto-detected — no configuration needed
+    make dev
+    ```
+  </TabItem>
+  <TabItem label="Docker">
+    ```bash
+    # Docker is used as fallback if Podman is not installed
+    make dev
+    ```
+  </TabItem>
+  <TabItem label="Override">
+    ```bash
+    # Force a specific compose command
+    COMPOSE="docker compose" make dev
+    ```
+  </TabItem>
+</Tabs>

--- a/src/content/docs/getting-started/quick-start.mdx
+++ b/src/content/docs/getting-started/quick-start.mdx
@@ -21,36 +21,29 @@ import { Steps } from '@astrojs/starlight/components';
    cd my-app
    ```
 
-3. **Configure your database**
+3. **Start services and the dev server**
 
-   Edit `config/config.toml` and set your database credentials:
+   The project includes a generated `compose.yml` and `Makefile`. One command starts your database, mail server, and the hot-reloading dev server:
 
-   ```toml
-   [database]
-   engine = "postgres"
-   host = "localhost"
-   port = 5432
-   name = "my_app_dev"
-   user = "postgres"
-   password = ""
-   ssl_mode = "disable"
+   ```bash
+   make dev
    ```
 
+   This starts your database container (PostgreSQL by default), Mailpit for local email testing, and the Air hot-reload server. Your app is running at `http://localhost:4000`.
+
+   :::tip
+   The `Makefile` auto-detects Podman or Docker — no configuration needed.
+   :::
+
 4. **Run migrations**
+
+   In a separate terminal:
 
    ```bash
    devify migrate
    ```
 
    This runs all pending migrations in dependency order — auth tables first, then RBAC tables.
-
-5. **Start the dev server**
-
-   ```bash
-   devify dev
-   ```
-
-   This starts a hot-reloading dev server using Air. Your app is running at `http://localhost:4000`.
 
 6. **Create your first module**
 


### PR DESCRIPTION
## Summary

- Add new **Local Development** page under Getting Started: covers Makefile targets, `devify compose`, custom `[services.*]` config, Podman/Docker auto-detection
- Update **Quick Start** to use `make dev` instead of manual database configuration
- Update **Installation** prerequisites to recommend Docker/Podman for containerized services
- Add `devify compose` command to **CLI Reference**

## Test plan

- [ ] Run `npm run build` — verified, 38 pages built successfully
- [ ] Check new Local Development page renders correctly with tables and code blocks
- [ ] Verify Quick Start flow still reads naturally with the updated steps
- [ ] Confirm sidebar shows the new page under Getting Started